### PR TITLE
Fixes non-killed AJAX queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ tmp
 .DS_Store
 .idea
 *.swp
+*.swo
 app/assets/css
 .sass-cache/
 out/

--- a/app/app.js
+++ b/app/app.js
@@ -24,4 +24,11 @@ angular.module('adagios', [
 
     .config(['$routeProvider', function ($routeProvider) {
         $routeProvider.otherwise({redirectTo: '/'});
+    }])
+
+    // Reinitialise objects on url change
+    .run(['$rootScope', 'reinitTables', function($rootScope, reinitTables) {
+        $rootScope.$on('$locationChangeStart', function() {
+            reinitTables();
+        });
     }]);

--- a/app/components/table/cell_duration/cell_duration.js
+++ b/app/components/table/cell_duration/cell_duration.js
@@ -6,6 +6,6 @@ angular.module('adagios.table.cell_duration', ['adagios.table'])
         angular.noop();
     }])
 
-    .run(['tableConfig', function (tableConfig) {
-        tableConfig.cellToFieldsMap.duration = ['last_state_change'];
+    .run(['tableGlobalConfig', function (tableGlobalConfig) {
+        tableGlobalConfig.cellToFieldsMap.duration = ['last_state_change'];
     }]);

--- a/app/components/table/cell_host/cell_host.js
+++ b/app/components/table/cell_host/cell_host.js
@@ -16,7 +16,7 @@ angular.module('adagios.table.cell_host', ['adagios.table'])
         }
     }])
 
-    .run(['tableConfig', function (tableConfig) {
-        tableConfig.cellToFieldsMap.host = ['host_state', 'host_name'];
-        tableConfig.cellWrappableField.host = 'host_name';
+    .run(['tableGlobalConfig', function (tableGlobalConfig) {
+        tableGlobalConfig.cellToFieldsMap.host = ['host_state', 'host_name'];
+        tableGlobalConfig.cellWrappableField.host = 'host_name';
     }]);

--- a/app/components/table/cell_host_address/cell_host_address.js
+++ b/app/components/table/cell_host_address/cell_host_address.js
@@ -6,6 +6,6 @@ angular.module('adagios.table.cell_host_address', ['adagios.table'])
         angular.noop();
     }])
 
-    .run(['tableConfig', function (tableConfig) {
-        tableConfig.cellToFieldsMap.host_address = ['host_address'];
+    .run(['tableGlobalConfig', function (tableGlobalConfig) {
+        tableGlobalConfig.cellToFieldsMap.host_address = ['host_address'];
     }]);

--- a/app/components/table/cell_host_status/cell_host_status.js
+++ b/app/components/table/cell_host_status/cell_host_status.js
@@ -23,6 +23,6 @@ angular.module('adagios.table.cell_host_status', ['adagios.table'])
         }
     }])
 
-    .run(['tableConfig', function (tableConfig) {
-        tableConfig.cellToFieldsMap.host_status = ['state', 'last_check', 'childs'];
+    .run(['tableGlobalConfig', function (tableGlobalConfig) {
+        tableGlobalConfig.cellToFieldsMap.host_status = ['state', 'last_check', 'childs'];
     }]);

--- a/app/components/table/cell_hosts_host/cell_hosts_host.js
+++ b/app/components/table/cell_hosts_host/cell_hosts_host.js
@@ -14,6 +14,6 @@ angular.module('adagios.table.cell_hosts_host', ['adagios.table'])
         }
     }])
 
-    .run(['tableConfig', function (tableConfig) {
-        tableConfig.cellToFieldsMap.hosts_host = ['name', 'state'];
+    .run(['tableGlobalConfig', function (tableGlobalConfig) {
+        tableGlobalConfig.cellToFieldsMap.hosts_host = ['name', 'state'];
     }]);

--- a/app/components/table/cell_last_check/cell_last_check.js
+++ b/app/components/table/cell_last_check/cell_last_check.js
@@ -6,6 +6,6 @@ angular.module('adagios.table.cell_last_check', ['adagios.table'])
         angular.noop();
     }])
 
-    .run(['tableConfig', function (tableConfig) {
-        tableConfig.cellToFieldsMap.last_check = ['last_check'];
+    .run(['tableGlobalConfig', function (tableGlobalConfig) {
+        tableGlobalConfig.cellToFieldsMap.last_check = ['last_check'];
     }]);

--- a/app/components/table/cell_service_check/cell_service_check.js
+++ b/app/components/table/cell_service_check/cell_service_check.js
@@ -12,6 +12,6 @@ angular.module('adagios.table.cell_service_check', ['adagios.table'])
         }
     }])
 
-    .run(['tableConfig', function (tableConfig) {
-        tableConfig.cellToFieldsMap.service_check = ['state', 'description', 'plugin_output'];
+    .run(['tableGlobalConfig', function (tableGlobalConfig) {
+        tableGlobalConfig.cellToFieldsMap.service_check = ['state', 'description', 'plugin_output'];
     }]);

--- a/app/components/table/table.js
+++ b/app/components/table/table.js
@@ -102,7 +102,7 @@ angular.module('adagios.table', ['adagios.live',
                         }
 
                         if (!!attrs.refreshInterval) {
-                            tableGlobalConfig.refreshInterval = parseInt(attrs.refreshInterval, 10);
+                            tableGlobalConfig.refreshInterval = parseInt(attrs.refreshInterval * 1000, 10);
                         }
 
 

--- a/app/components/table/table.js
+++ b/app/components/table/table.js
@@ -139,7 +139,7 @@ angular.module('adagios.table', ['adagios.live',
         };
     }])
 
-    .service('resetTables', ['$interval', 'ajaxQueries', 'tablesConfig', 'tableGlobalConfig',
+    .service('reinitTables', ['$interval', 'ajaxQueries', 'tablesConfig', 'tableGlobalConfig',
         function ($interval, ajaxQueries, tablesConfig, tableGlobalConfig) {
             return function () {
                 // Stop AJAX queries
@@ -147,8 +147,7 @@ angular.module('adagios.table', ['adagios.live',
                     $interval.cancel(promise);
                 });
 
-                // Delete tables config
-                tablesConfig.length = 0;
+                // Reinitialise table index
                 tableGlobalConfig.nextTableIndex = 0;
             };
         }])

--- a/app/components/table/table.js
+++ b/app/components/table/table.js
@@ -211,16 +211,16 @@ angular.module('adagios.table', ['adagios.live',
             var newItems = [],
                 previous,
                 fieldToCompare = tableGlobalConfig.cellWrappableField[tablesConfig[scope.tableIndex].noRepeatCell],
-                new_attr = tablesConfig[scope.tableIndex].noRepeatCell + "_additionnalClass";
+                newAttr = tablesConfig[scope.tableIndex].noRepeatCell + "_additionnalClass";
 
             angular.forEach(items, function (item) {
 
                 if (previous === item[fieldToCompare]) {
-                    item[new_attr] = 'state--rmChild';
+                    item[newAttr] = 'state--rmChild';
                 } else {
                     previous = item[fieldToCompare].slice(0);
-                    if (!!item[new_attr]) {
-                        item[new_attr] = item[new_attr].replace("state--rmChild", "");
+                    if (!!item[newAttr]) {
+                        item[newAttr] = item[newAttr].replace("state--rmChild", "");
                     }
                 }
                 newItems.push(item);

--- a/app/dashboard/dashboard.html
+++ b/app/dashboard/dashboard.html
@@ -1,4 +1,4 @@
-<article ng-controller="DashboardCtrl" id="tactical">
+<article id="tactical">
   <header class="main__overview">
     <h2 class="main__overview__title">{{dashboardTactical[0].title}}</h2>
     

--- a/app/dashboard/dashboard.js
+++ b/app/dashboard/dashboard.js
@@ -15,18 +15,16 @@ angular.module('adagios.view.dashboard', ['ngRoute',
         });
     }])
 
-    .controller('DashboardCtrl', ['$scope', '$routeParams', 'dashboardConfig', 'getServices', 'resetTables',
+    .controller('DashboardCtrl', ['$scope', '$routeParams', 'dashboardConfig', 'getServices', 
         'TableConfigObj', 'TacticalConfigObj', 'getHostOpenProblems', 'getServiceOpenProblems', 'getHostProblems',
         'getServiceProblems',
-        function ($scope, $routeParams, dashboardConfig, getServices, resetTables, TableConfigObj,
+        function ($scope, $routeParams, dashboardConfig, getServices, TableConfigObj,
             TacticalConfigObj, getHostOpenProblems, getServiceOpenProblems, getHostProblems, getServiceProblems) {
             var components = [],
                 component,
                 config,
                 viewName,
                 i = 0;
-
-            resetTables();
 
             if (!!$routeParams.view) {
                 viewName = $routeParams.view;

--- a/app/dashboard/dashboard.js
+++ b/app/dashboard/dashboard.js
@@ -15,10 +15,10 @@ angular.module('adagios.view.dashboard', ['ngRoute',
         });
     }])
 
-    .controller('DashboardCtrl', ['$scope', '$routeParams', 'dashboardConfig', 'getServices', 'tableConfig',
+    .controller('DashboardCtrl', ['$scope', '$routeParams', 'dashboardConfig', 'getServices', 'resetTables',
         'TableConfigObj', 'TacticalConfigObj', 'getHostOpenProblems', 'getServiceOpenProblems', 'getHostProblems',
         'getServiceProblems',
-        function ($scope, $routeParams, dashboardConfig, getServices, tableConfig, TableConfigObj,
+        function ($scope, $routeParams, dashboardConfig, getServices, resetTables, TableConfigObj,
             TacticalConfigObj, getHostOpenProblems, getServiceOpenProblems, getHostProblems, getServiceProblems) {
             var components = [],
                 component,
@@ -26,7 +26,7 @@ angular.module('adagios.view.dashboard', ['ngRoute',
                 viewName,
                 i = 0;
 
-            tableConfig.index = 0;
+            resetTables();
 
             if (!!$routeParams.view) {
                 viewName = $routeParams.view;

--- a/app/single_table/single_table.js
+++ b/app/single_table/single_table.js
@@ -16,11 +16,11 @@ angular.module('adagios.view.singleTable', ['ngRoute',
         });
     }])
 
-    .controller('SingleTableCtrl', ['$scope', '$routeParams', 'singleTableConfig', 'tableConfig', 'TableConfigObj',
-        function ($scope, $routeParams, singleTableConfig, tableConfig, TableConfigObj) {
+    .controller('SingleTableCtrl', ['$scope', '$routeParams', 'singleTableConfig', 'resetTables', 'TableConfigObj',
+        function ($scope, $routeParams, singleTableConfig, resetTables, TableConfigObj) {
             var viewName = "";
 
-            tableConfig.index = 0;
+            resetTables();
 
             if (!!$routeParams.view) {
                 viewName = $routeParams.view;

--- a/app/single_table/single_table.js
+++ b/app/single_table/single_table.js
@@ -16,11 +16,9 @@ angular.module('adagios.view.singleTable', ['ngRoute',
         });
     }])
 
-    .controller('SingleTableCtrl', ['$scope', '$routeParams', 'singleTableConfig', 'resetTables', 'TableConfigObj',
-        function ($scope, $routeParams, singleTableConfig, resetTables, TableConfigObj) {
+    .controller('SingleTableCtrl', ['$scope', '$routeParams', 'singleTableConfig', 'TableConfigObj',
+        function ($scope, $routeParams, singleTableConfig, TableConfigObj) {
             var viewName = "";
-
-            resetTables();
 
             if (!!$routeParams.view) {
                 viewName = $routeParams.view;


### PR DESCRIPTION
Fixes #34.

- Splitted tableConfig into tableGlobalConfig and tablesConfig.
- Last view's AJAX queries are now killed
- Reinitialisation needed on view/url change will now be handled by the main module via $locationChangeSuccess callback so that we won't have to reinitialise table config (and further config in the future) on the first line of every view controller. 
