### PR TITLE
Single endpoint providing all view templates

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -109,9 +109,9 @@ module.exports = function (grunt) {
                         '<%= project.app %>/components/table/cell_hosts_host/cell_hosts_host.js',
                         '<%= project.app %>/components/table/cell_host_address/cell_host_address.js',
                         '<%= project.app %>/components/table/cell_host_status/cell_host_status.js',
-                        '<%= project.app %>/dashboard/dashboard.js',
                         '<%= project.app %>/routing_view/routing_view.js',
-                        '<%= project.app %>/single_table/single_table.js'
+                        '<%= project.app %>/templates/dashboard/dashboard.js',
+                        '<%= project.app %>/templates/single_table/single_table.js'
                     ]
                 }],
                 options: {
@@ -143,9 +143,9 @@ module.exports = function (grunt) {
                         '<%= project.build %>/components/table/cell_hosts_host/cell_hosts_host.js': '<%= project.app %>/components/table/cell_hosts_host/cell_hosts_host.js',
                         '<%= project.build %>/components/table/cell_host_address/cell_host_address.js': '<%= project.app %>/components/table/cell_host_address/cell_host_address.js',
                         '<%= project.build %>/components/table/cell_host_status/cell_host_status.js': '<%= project.app %>/components/table/cell_host_status/cell_host_status.js',
-                        '<%= project.build %>/dashboard/dashboard.js': '<%= project.app %>/dashboard/dashboard.js',
                         '<%= project.build %>/routing_view/routing_view.js': '<%= project.app %>/routing_view/routing_view.js',
-                        '<%= project.build %>/single_table/single_table.js' : '<%= project.app %>/single_table/single_table.js'
+                        '<%= project.build %>/templates/dashboard/dashboard.js': '<%= project.app %>/templates/dashboard/dashboard.js',
+                        '<%= project.build %>/templates/single_table/single_table.js' : '<%= project.app %>/templates/single_table/single_table.js'
                     },
                     {
                         '<%= project.build %>/js/adagios.min.js' : [
@@ -171,9 +171,9 @@ module.exports = function (grunt) {
                             '<%= project.build %>/components/table/cell_hosts_host/cell_hosts_host.js',
                             '<%= project.build %>/components/table/cell_host_address/cell_host_address.js',
                             '<%= project.build %>/components/table/cell_host_status/cell_host_status.js',
-                            '<%= project.build %>/dashboard/dashboard.js',
                             '<%= project.build %>/routing_view/routing_view.js',
-                            '<%= project.build %>/single_table/single_table.js'
+                            '<%= project.build %>/templates/dashboard/dashboard.js',
+                            '<%= project.build %>/templates/single_table/single_table.js'
                         ]
                     }
                 ],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -110,6 +110,7 @@ module.exports = function (grunt) {
                         '<%= project.app %>/components/table/cell_host_address/cell_host_address.js',
                         '<%= project.app %>/components/table/cell_host_status/cell_host_status.js',
                         '<%= project.app %>/dashboard/dashboard.js',
+                        '<%= project.app %>/routing_view/routing_view.js',
                         '<%= project.app %>/single_table/single_table.js'
                     ]
                 }],
@@ -143,6 +144,7 @@ module.exports = function (grunt) {
                         '<%= project.build %>/components/table/cell_host_address/cell_host_address.js': '<%= project.app %>/components/table/cell_host_address/cell_host_address.js',
                         '<%= project.build %>/components/table/cell_host_status/cell_host_status.js': '<%= project.app %>/components/table/cell_host_status/cell_host_status.js',
                         '<%= project.build %>/dashboard/dashboard.js': '<%= project.app %>/dashboard/dashboard.js',
+                        '<%= project.build %>/routing_view/routing_view.js': '<%= project.app %>/routing_view/routing_view.js',
                         '<%= project.build %>/single_table/single_table.js' : '<%= project.app %>/single_table/single_table.js'
                     },
                     {
@@ -170,6 +172,7 @@ module.exports = function (grunt) {
                             '<%= project.build %>/components/table/cell_host_address/cell_host_address.js',
                             '<%= project.build %>/components/table/cell_host_status/cell_host_status.js',
                             '<%= project.build %>/dashboard/dashboard.js',
+                            '<%= project.build %>/routing_view/routing_view.js',
                             '<%= project.build %>/single_table/single_table.js'
                         ]
                     }

--- a/app/app.js
+++ b/app/app.js
@@ -19,7 +19,8 @@ angular.module('adagios', [
     'adagios.topbar',
     'adagios.config',
     'adagios.view.dashboard',
-    'adagios.view.singleTable'
+    'adagios.view.singleTable',
+    'adagios.view'
 ])
 
     .config(['$routeProvider', function ($routeProvider) {

--- a/app/app.js
+++ b/app/app.js
@@ -28,8 +28,8 @@ angular.module('adagios', [
     }])
 
     // Reinitialise objects on url change
-    .run(['$rootScope', 'reinitTables', function($rootScope, reinitTables) {
-        $rootScope.$on('$locationChangeStart', function() {
+    .run(['$rootScope', 'reinitTables', function ($rootScope, reinitTables) {
+        $rootScope.$on('$locationChangeStart', function () {
             reinitTables();
         });
     }]);

--- a/app/components/config/config.json
+++ b/app/components/config/config.json
@@ -147,7 +147,7 @@
     "hostsConfig": {
 		"title": "Hosts",
 		"refreshInterval": 0,
-		"template": "singleTable",
+		"template": "single_table",
 		"components": [
 			{
 				"type": "table",
@@ -180,7 +180,7 @@
     "servicesConfig": {
 		"title": "Services",
 		"refreshInterval": 0,
-		"template": "singleTable",
+		"template": "single_table",
         "components": [{
 			"type": "table",
 			"config": {

--- a/app/components/sidebar/sidebar.html
+++ b/app/components/sidebar/sidebar.html
@@ -22,9 +22,9 @@
         </button>
         
         <ul class="sidebar__sublist collapse in" id="shortcutList">
-          <li class="sidebar__subitem"><a ng-class="getClass('/dashboard?view=dashboardConfig')" href="#/dashboard?view=dashboardConfig">Dashboard</a></li>
-          <li class="sidebar__subitem"><a ng-class="getClass('/singleTable?view=hostsConfig')" href="#/singleTable?view=hostsConfig">Hosts</a></li>
-          <li class="sidebar__subitem"><a ng-class="getClass('/singleTable?view=servicesConfig')" href="#/singleTable?view=servicesConfig">Services</a></li>
+          <li class="sidebar__subitem"><a ng-class="getClass('/view?view=dashboardConfig')" href="#/view?view=dashboardConfig">Dashboard</a></li>
+          <li class="sidebar__subitem"><a ng-class="getClass('/view?view=hostsConfig')" href="#/view?view=hostsConfig">Hosts</a></li>
+          <li class="sidebar__subitem"><a ng-class="getClass('/view?view=servicesConfig')" href="#/view?view=servicesConfig">Services</a></li>
           <li class="sidebar__subitem"><a href="#">Networks parents</a></li>
         </ul>
       </li>

--- a/app/routing_view/routing_view.js
+++ b/app/routing_view/routing_view.js
@@ -16,7 +16,13 @@ angular.module('adagios.view', ['ngRoute',
     .controller('ViewCtrl', ['$scope', '$routeParams', 'viewsTemplate',
         function ($scope, $routeParams, viewsTemplate) {
             var templateName = viewsTemplate[$routeParams.view],
-                templateUrl = templateName + '/' + templateName + '.html';
+                templateUrl = 'templates/' + templateName + '/' + templateName + '.html';
+
+            if (!!$routeParams.view) {
+                $scope.viewName = $routeParams.view;
+            } else {
+                throw new Error("ERROR : 'view' GET parameter must be the custom view name");
+            }
 
             $scope.templateUrl = templateUrl;
         }])

--- a/app/routing_view/routing_view.js
+++ b/app/routing_view/routing_view.js
@@ -1,0 +1,30 @@
+'use strict';
+
+angular.module('adagios.view', ['ngRoute',
+                                'adagios.config'
+                               ])
+
+    .value('viewsTemplate', {})
+
+    .config(['$routeProvider', function ($routeProvider) {
+        $routeProvider.when('/view', {
+            controller: 'ViewCtrl',
+            template: '<div ng-include="templateUrl">Loading...</div>'
+        });
+    }])
+
+    .controller('ViewCtrl', ['$scope', '$routeParams', 'viewsTemplate',
+        function ($scope, $routeParams, viewsTemplate) {
+            var templateName = viewsTemplate[$routeParams.view],
+                templateUrl = templateName + '/' + templateName + '.html';
+
+            $scope.templateUrl = templateUrl;
+        }])
+
+    .run(['readConfig', 'viewsTemplate', function (readConfig, viewsTemplate) {
+        var viewsConfig = readConfig.data;
+
+        angular.forEach(viewsConfig, function (config, view) {
+            viewsTemplate[view] = config.template;
+        });
+    }]);

--- a/app/templates/dashboard/dashboard.html
+++ b/app/templates/dashboard/dashboard.html
@@ -1,4 +1,4 @@
-<article id="tactical">
+<article ng-controller="DashboardCtrl" id="tactical">
   <header class="main__overview">
     <h2 class="main__overview__title">{{dashboardTactical[0].title}}</h2>
     

--- a/app/templates/dashboard/dashboard.js
+++ b/app/templates/dashboard/dashboard.js
@@ -8,14 +8,7 @@ angular.module('adagios.view.dashboard', ['ngRoute',
 
     .value('dashboardConfig', {})
 
-    .config(['$routeProvider', function ($routeProvider) {
-        $routeProvider.when('/dashboard', {
-            templateUrl: 'dashboard/dashboard.html',
-            controller: 'DashboardCtrl'
-        });
-    }])
-
-    .controller('DashboardCtrl', ['$scope', '$routeParams', 'dashboardConfig', 'getServices', 
+    .controller('DashboardCtrl', ['$scope', '$routeParams', 'dashboardConfig', 'getServices',
         'TableConfigObj', 'TacticalConfigObj', 'getHostOpenProblems', 'getServiceOpenProblems', 'getHostProblems',
         'getServiceProblems',
         function ($scope, $routeParams, dashboardConfig, getServices, TableConfigObj,
@@ -23,14 +16,8 @@ angular.module('adagios.view.dashboard', ['ngRoute',
             var components = [],
                 component,
                 config,
-                viewName,
+                viewName = $scope.viewName,
                 i = 0;
-
-            if (!!$routeParams.view) {
-                viewName = $routeParams.view;
-            } else {
-                throw new Error("ERROR : 'view' GET parameter must be the custom view name");
-            }
 
             $scope.dashboardTitle = dashboardConfig[viewName].title;
             $scope.dashboardTemplate = dashboardConfig[viewName].template;

--- a/app/templates/single_table/single_table.html
+++ b/app/templates/single_table/single_table.html
@@ -1,4 +1,4 @@
-<article id="tactical">
+<article ng-controller="SingleTableCtrl" id="tactical">
 
   <section class="main__content tabpanel">
 

--- a/app/templates/single_table/single_table.js
+++ b/app/templates/single_table/single_table.js
@@ -9,22 +9,9 @@ angular.module('adagios.view.singleTable', ['ngRoute',
 
     .value('singleTableConfig', {})
 
-    .config(['$routeProvider', function ($routeProvider) {
-        $routeProvider.when('/singleTable', {
-            templateUrl: 'single_table/single_table.html',
-            controller: 'SingleTableCtrl'
-        });
-    }])
-
     .controller('SingleTableCtrl', ['$scope', '$routeParams', 'singleTableConfig', 'TableConfigObj',
         function ($scope, $routeParams, singleTableConfig, TableConfigObj) {
-            var viewName = "";
-
-            if (!!$routeParams.view) {
-                viewName = $routeParams.view;
-            } else {
-                throw new Error("ERROR : 'view' GET parameter must be the custom view name");
-            }
+            var viewName = $scope.viewName;
 
             $scope.tableConfig = new TableConfigObj(singleTableConfig[viewName].components[0].config);
 
@@ -36,7 +23,7 @@ angular.module('adagios.view.singleTable', ['ngRoute',
         var viewsConfig = readConfig.data;
 
         angular.forEach(viewsConfig, function (config, view) {
-            if (config.template === 'singleTable') {
+            if (config.template === 'single_table') {
                 singleTableConfig[view] = config;
             }
         });


### PR DESCRIPTION
The `/view` endpoint now provides routing to all views given a `view` parameter and the view entry name in the config file.
It is now possible to dynamically resolve routes, allowing to configure which template will be loaded for every views. 

`/view?view=dashboardConfig` will use dashboardConfig template which is configured to dashboard.html
`/view?view=hostsConfig` will use hostsConfig template which is configured to single_table.html
...

Up to now, we had to use a static route per template : 
`/dashboard?view=dashboardConfig`
`/singleTable?view=hostsConfig`