### PR TITLE
AJAX redundant queries and real data in dashboard view

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -88,9 +88,10 @@ module.exports = function (grunt) {
                 files: [{
                     '<%= project.build %>/js/adagios.min.js' : [
                         '<%= project.app %>/app.js',
+                        '<%= project.app %>/app.js',
                         '<%= project.app %>/components/config/config.js',
+                        '<%= project.app %>/components/utils/promise_manager.js',
                         '<%= project.app %>/components/live/live.js',
-                        '<%= project.app %>/components/live/notifications.js',
                         '<%= project.app %>/components/live/get_objects.js',
                         '<%= project.app %>/components/ng-justgage/ng-justgage.js',
                         '<%= project.app %>/components/filters/filters.js',
@@ -135,8 +136,8 @@ module.exports = function (grunt) {
                     {
                         '<%= project.build %>/app.js': '<%= project.app %>/app.js',
                         '<%= project.build %>/components/config/config.js': '<%= project.app %>/components/config/config.js',
+                        '<%= project.build %>/components/utils/promise_manager.js': '<%= project.app %>/components/utils/promise_manager.js',
                         '<%= project.build %>/components/live/live.js': '<%= project.app %>/components/live/live.js',
-                        '<%= project.build %>/components/live/notifications.js': '<%= project.app %>/components/live/notifications.js',
                         '<%= project.build %>/components/live/get_objects.js': '<%= project.app %>/components/live/get_objects.js',
                         '<%= project.build %>/components/ng-justgage/ng-justgage.js': '<%= project.app %>/components/ng-justgage/ng-justgage.js',
                         '<%= project.build %>/components/filters/filters.js': '<%= project.app %>/components/filters/filters.js',
@@ -177,8 +178,8 @@ module.exports = function (grunt) {
                         '<%= project.build %>/js/adagios.min.js' : [
                             '<%= project.build %>/app.js',
                             '<%= project.build %>/components/config/config.js',
+                            '<%= project.build %>/components/utils/promise_manager.js',
                             '<%= project.build %>/components/live/live.js',
-                            '<%= project.build %>/components/live/notifications.js',
                             '<%= project.build %>/components/live/get_objects.js',
                             '<%= project.build %>/components/ng-justgage/ng-justgage.js',
                             '<%= project.build %>/components/filters/filters.js',

--- a/app/app.js
+++ b/app/app.js
@@ -33,8 +33,9 @@ angular.module('adagios', [
     }])
 
     // Reinitialise objects on url change
-    .run(['$rootScope', 'reinitTables', function ($rootScope, reinitTables) {
+    .run(['$rootScope', 'clearAjaxPromises', 'reinitTables', function ($rootScope, clearAjaxPromises, reinitTables) {
         $rootScope.$on('$locationChangeStart', function () {
             reinitTables();
+            clearAjaxPromises();
         });
     }]);

--- a/app/app.js
+++ b/app/app.js
@@ -16,6 +16,7 @@ angular.element(document).ready(function () {
 angular.module('adagios', [
     'ngRoute',
     'adagios.config',
+    'adagios.utils.promiseManager',
     'adagios.topbar',
     'adagios.sidebar',
     'adagios.host',

--- a/app/components/config/config.json
+++ b/app/components/config/config.json
@@ -9,9 +9,9 @@
                 "config": {
                     "title": "Tactical Overview",
                     "components": {
-                        "statusOverview": "true",
-                        "currentHealth": "true",
-                        "topAlertProducers": "false"
+                        "statusOverview": true,
+                        "currentHealth": true,
+                        "topAlertProducers": false
                     }
                 }
             },

--- a/app/components/config/config.json
+++ b/app/components/config/config.json
@@ -1,219 +1,221 @@
 {
     "dashboardConfig": {
-		"title": "Unhandled service problems",
-		"refreshInterval": 0,
-		"template": "dashboard",
-		"components" : [
-			{
-				"type": "tactical",
-				"config": {
-					"title": "Tactical Overview",
-					"components": {
-						"statusOverview": "true",
-						"currentHealth": "true",
-						"topAlertProducers": "true"
-					}
-				}
-			},
-			{
-				"type": "table",
-				"config": {
-					"title": "Hosts",
-					"cells": {
-						"text": [
-							"Host",
-							"Address",
-							"Duration",
-							"Last check",
-							"Host status"
-						],
-						"name": [
-							"hosts_host",
-							"host_address",
-							"duration",
-							"last_check",
-							"host_status"
-						]
-					},
-					"apiName": "hosts",
-					"additionnalQueryFields": {
-						"acknowledged": 0,
-						"state": 1
-					},
-					"isWrappable" : false,
-					"noRepeatCell" : ""
-				}
-			},
-			{
-				"type": "table",
-				"config": {
-					"title": "Service problems",
-					"cells": {
-						"text": [
-							"Host",
-							"Service check",
-							"Duration",
-							"Last check"
-						],
-						"name": [
-							"host",
-							"service_check",
-							"duration",
-							"last_check"
-						]
-					},
-					"apiName": "services",
-					"filters": {
-						"isnot": {
-							"state": [
-								"0"
-							],
-							"host_state": [
-								"2"
-							]
-						}
-					},
-					"additionnalQueryFields": {
-						"acknowledged": 0
-					},
-					"isWrappable" : true,
-					"noRepeatCell" : "host"
-				}
-			},
-			{
-				"type": "table",
-				"config": {
-					"title": "Hosts",
-					"cells": {
-						"text": [
-							"Host",
-							"Address",
-							"Duration",
-							"Last check",
-							"Host status"
-						],
-						"name": [
-							"hosts_host",
-							"host_address",
-							"duration",
-							"last_check",
-							"host_status"
-						]
-					},
-					"apiName": "hosts",
-					"filters": {
-						"isnot": {
-							"state": [
-								"0"
-							]
-						}
-					},
-					"isWrappable" : false,
-					"noRepeatCell" : ""
-				}
-			},
-			{
-				"type": "table",
-				"config": {
-					"title": "Service problems",
-					"cells": {
-						"text": [
-							"Host",
-							"Service check",
-							"Duration",
-							"Last check"
-						],
-						"name": [
-							"host",
-							"service_check",
-							"duration",
-							"last_check"
-						]
-					},
-					"apiName": "services",
-					"filters": {
-						"isnot": {
-							"state": [
-								"0"
-							]
-						}
-					},
-					"isWrappable" : true,
-					"noRepeatCell" : "host"
-				}
-			}
-		]
+        "title": "Unhandled service problems",
+        "refreshInterval": 0,
+        "template": "dashboard",
+        "components": [
+            {
+                "type": "tactical",
+                "config": {
+                    "title": "Tactical Overview",
+                    "components": {
+                        "statusOverview": "true",
+                        "currentHealth": "true",
+                        "topAlertProducers": "false"
+                    }
+                }
+            },
+            {
+                "type": "table",
+                "config": {
+                    "title": "Hosts",
+                    "cells": {
+                        "text": [
+                            "Host",
+                            "Address",
+                            "Duration",
+                            "Last check",
+                            "Host status"
+                        ],
+                        "name": [
+                            "hosts_host",
+                            "host_address",
+                            "duration",
+                            "last_check",
+                            "host_status"
+                        ]
+                    },
+                    "apiName": "hosts",
+                    "additionnalQueryFields": {
+                        "acknowledged": 0,
+                        "state": 1
+                    },
+                    "isWrappable": false,
+                    "noRepeatCell": ""
+                }
+            },
+            {
+                "type": "table",
+                "config": {
+                    "title": "Service problems",
+                    "cells": {
+                        "text": [
+                            "Host",
+                            "Service check",
+                            "Duration",
+                            "Last check"
+                        ],
+                        "name": [
+                            "host",
+                            "service_check",
+                            "duration",
+                            "last_check"
+                        ]
+                    },
+                    "apiName": "services",
+                    "filters": {
+                        "isnot": {
+                            "state": [
+                                "0"
+                            ],
+                            "host_state": [
+                                "2"
+                            ]
+                        }
+                    },
+                    "additionnalQueryFields": {
+                        "acknowledged": 0
+                    },
+                    "isWrappable": true,
+                    "noRepeatCell": "host"
+                }
+            },
+            {
+                "type": "table",
+                "config": {
+                    "title": "Hosts",
+                    "cells": {
+                        "text": [
+                            "Host",
+                            "Address",
+                            "Duration",
+                            "Last check",
+                            "Host status"
+                        ],
+                        "name": [
+                            "hosts_host",
+                            "host_address",
+                            "duration",
+                            "last_check",
+                            "host_status"
+                        ]
+                    },
+                    "apiName": "hosts",
+                    "filters": {
+                        "isnot": {
+                            "state": [
+                                "0"
+                            ]
+                        }
+                    },
+                    "isWrappable": false,
+                    "noRepeatCell": ""
+                }
+            },
+            {
+                "type": "table",
+                "config": {
+                    "title": "Service problems",
+                    "cells": {
+                        "text": [
+                            "Host",
+                            "Service check",
+                            "Duration",
+                            "Last check"
+                        ],
+                        "name": [
+                            "host",
+                            "service_check",
+                            "duration",
+                            "last_check"
+                        ]
+                    },
+                    "apiName": "services",
+                    "filters": {
+                        "isnot": {
+                            "state": [
+                                "0"
+                            ]
+                        }
+                    },
+                    "isWrappable": true,
+                    "noRepeatCell": "host"
+                }
+            }
+        ]
     },
     "hostsConfig": {
-		"title": "Hosts",
-		"refreshInterval": 0,
-		"template": "single_table",
-		"components": [
-			{
-				"type": "table",
-				"config": {
-					"title": "Hosts",
-					"cells": {
-						"text": [
-							"Host",
-							"Address",
-							"Duration",
-							"Last check",
-							"Host status"
-						],
-						"name": [
-							"hosts_host",
-							"host_address",
-							"duration",
-							"last_check",
-							"host_status"
-						]
-					},
-					"apiName": "hosts",
-					"filters": {},
-					"isWrappable" : false,
-					"noRepeatCell" : ""
-				}
-			}
-		]
-	},
+        "title": "Hosts",
+        "refreshInterval": 0,
+        "template": "single_table",
+        "components": [
+            {
+                "type": "table",
+                "config": {
+                    "title": "Hosts",
+                    "cells": {
+                        "text": [
+                            "Host",
+                            "Address",
+                            "Duration",
+                            "Last check",
+                            "Host status"
+                        ],
+                        "name": [
+                            "hosts_host",
+                            "host_address",
+                            "duration",
+                            "last_check",
+                            "host_status"
+                        ]
+                    },
+                    "apiName": "hosts",
+                    "filters": {},
+                    "isWrappable": false,
+                    "noRepeatCell": ""
+                }
+            }
+        ]
+    },
     "servicesConfig": {
-		"title": "Services",
-		"refreshInterval": 0,
-		"template": "single_table",
-        "components": [{
-			"type": "table",
-			"config": {
-				"title": "Services",
-				"cells": {
-					"text": [
-						"Host",
-						"Service check",
-						"Duration",
-						"Last check"
-					],
-					"name": [
-						"host",
-						"service_check",
-						"duration",
-						"last_check"
-					]
-				},
-				"apiName": "services",
-				"filters": {},
-				"isWrappable" : false,
-				"noRepeatCell" : "host"
-			}
-		}]
+        "title": "Services",
+        "refreshInterval": 0,
+        "template": "single_table",
+        "components": [
+            {
+                "type": "table",
+                "config": {
+                    "title": "Services",
+                    "cells": {
+                        "text": [
+                            "Host",
+                            "Service check",
+                            "Duration",
+                            "Last check"
+                        ],
+                        "name": [
+                            "host",
+                            "service_check",
+                            "duration",
+                            "last_check"
+                        ]
+                    },
+                    "apiName": "services",
+                    "filters": {},
+                    "isWrappable": false,
+                    "noRepeatCell": "host"
+                }
+            }
+        ]
     },
     "host": {
-		"title": "Host",
-		"refreshInterval": 0,
-		"template": "host"
+	"title": "Host",
+	"refreshInterval": 0,
+	"template": "host"
     },
     "service": {
-		"title": "Service",
-		"refreshInterval": 0,
-		"template": "service"
+	"title": "Service",
+	"refreshInterval": 0,
+	"template": "service"
     }
 }

--- a/app/components/host/host_info/host_info.js
+++ b/app/components/host/host_info/host_info.js
@@ -3,10 +3,10 @@
 angular.module('adagios.host.info', [])
 
     .controller('HostInfoCtrl', ['$scope', function ($scope) {
-        $scope.active_checks = ($scope.data.live.active_checks_enabled === '1') ? 'Enabled': 'Disabled';
-        $scope.notifications_enabled = ($scope.data.config.notifications_enabled === '1') ? 'Enabled': 'Disabled';
-        $scope.event_handler_enabled = ($scope.data.config.event_handler_enabled === '1') ? 'Enabled': 'Disabled';
-        $scope.flap_detection_enabled = ($scope.data.config.flap_detection_enabled === '1') ? 'Enabled': 'Disabled';
+        $scope.active_checks = ($scope.data.live.active_checks_enabled === '1') ? 'Enabled' : 'Disabled';
+        $scope.notifications_enabled = ($scope.data.config.notifications_enabled === '1') ? 'Enabled' : 'Disabled';
+        $scope.event_handler_enabled = ($scope.data.config.event_handler_enabled === '1') ? 'Enabled' : 'Disabled';
+        $scope.flap_detection_enabled = ($scope.data.config.flap_detection_enabled === '1') ? 'Enabled' : 'Disabled';
     }])
 
     .directive('adgHostInfo', function () {

--- a/app/components/live/get_objects.js
+++ b/app/components/live/get_objects.js
@@ -73,7 +73,7 @@ angular.module('adagios.live')
 
             return getObjects(fields, filters, apiName, additionnalQueryFields)
                 .error(function () {
-                    throw new Error('getObjects : GET Request failed');
+                    throw new Error('getHostOpenProblems : GET Request failed');
                 });
         }])
 
@@ -87,7 +87,7 @@ angular.module('adagios.live')
 
             return getObjects(fields, filters, apiName, additionnalQueryFields)
                 .error(function () {
-                    throw new Error('getObjects : GET Request failed');
+                    throw new Error('getServiceOpenProblems : GET Request failed');
                 });
         }])
 
@@ -101,7 +101,7 @@ angular.module('adagios.live')
 
             return getObjects(fields, filters, apiName, additionnalQueryFields)
                 .error(function () {
-                    throw new Error('getObjects : GET Request failed');
+                    throw new Error('getHostProblems : GET Request failed');
                 });
         }])
 
@@ -115,7 +115,35 @@ angular.module('adagios.live')
 
             return getObjects(fields, filters, apiName, additionnalQueryFields)
                 .error(function () {
-                    throw new Error('getObjects : GET Request failed');
+                    throw new Error('getServiceOpenProblems : GET Request failed');
+                });
+        }])
+
+    // This service is used to count the number of hosts
+    .service('getTotalHosts', ['$http', 'getObjects',
+        function ($http, getObjects) {
+            var fields = ['name'],
+                filters = {},
+                apiName = 'hosts',
+                additionnalQueryFields = {};
+
+            return getObjects(fields, filters, apiName, additionnalQueryFields)
+                .error(function () {
+                    throw new Error('getTotalHosts : GET Request failed');
+                });
+        }])
+
+    // This service is used to count the number of services
+    .service('getTotalServices', ['$http', 'getObjects',
+        function ($http, getObjects) {
+            var fields = ['name'],
+                filters = {},
+                apiName = 'services',
+                additionnalQueryFields = {};
+
+            return getObjects(fields, filters, apiName, additionnalQueryFields)
+                .error(function () {
+                    throw new Error('getTotalServices : GET Request failed');
                 });
         }])
 

--- a/app/components/live/get_objects.js
+++ b/app/components/live/get_objects.js
@@ -56,95 +56,107 @@ angular.module('adagios.live')
     .service('getService', ['$http',
         function ($http) {
             return function (hostName, description) {
-            return $http.get('/rest/status/json/services/?host_name=' + hostName + '&description=' + description)
-                .error(function () {
-                    throw new Error('getService : GET Request failed');
-                });
-            }
+                return $http.get('/rest/status/json/services/?host_name=' + hostName + '&description=' + description)
+                    .error(function () {
+                        throw new Error('getService : GET Request failed');
+                    });
+            };
         }])
 
     // This service is used to count the number of host open problems
     .service('getHostOpenProblems', ['$http', 'getObjects',
         function ($http, getObjects) {
-            var fields = ['state'],
-                filters = {},
-                apiName = 'hosts',
-                additionnalQueryFields = {'acknowledged': 0, 'state': 1};
+            return function () {
+                var fields = ['state'],
+                    filters = {},
+                    apiName = 'hosts',
+                    additionnalQueryFields = {'acknowledged': 0, 'state': 1};
 
-            return getObjects(fields, filters, apiName, additionnalQueryFields)
-                .error(function () {
-                    throw new Error('getHostOpenProblems : GET Request failed');
-                });
+                return getObjects(fields, filters, apiName, additionnalQueryFields)
+                    .error(function () {
+                        throw new Error('getHostOpenProblems : GET Request failed');
+                    });
+            };
         }])
 
     // This service is used to count the number of service open problems
     .service('getServiceOpenProblems', ['$http', 'getObjects',
         function ($http, getObjects) {
-            var fields = ['state'],
-                filters = { "isnot": { "state": [ "0" ], "host_state": [ "2" ] }},
-                apiName = 'services',
-                additionnalQueryFields = {'acknowledged': 0};
+            return function () {
+                var fields = ['state'],
+                    filters = { "isnot": { "state": [ "0" ], "host_state": [ "2" ] }},
+                    apiName = 'services',
+                    additionnalQueryFields = {'acknowledged': 0};
 
-            return getObjects(fields, filters, apiName, additionnalQueryFields)
-                .error(function () {
-                    throw new Error('getServiceOpenProblems : GET Request failed');
-                });
+                return getObjects(fields, filters, apiName, additionnalQueryFields)
+                    .error(function () {
+                        throw new Error('getServiceOpenProblems : GET Request failed');
+                    });
+            };
         }])
 
     // This service is used to count the number of host problems
     .service('getHostProblems', ['$http', 'getObjects',
         function ($http, getObjects) {
-            var fields = ['state'],
-                filters = { 'isnot': {'state': [0]} },
-                apiName = 'hosts',
-                additionnalQueryFields = {};
+            return function () {
+                var fields = ['state'],
+                    filters = { 'isnot': {'state': [0]} },
+                    apiName = 'hosts',
+                    additionnalQueryFields = {};
 
-            return getObjects(fields, filters, apiName, additionnalQueryFields)
-                .error(function () {
-                    throw new Error('getHostProblems : GET Request failed');
-                });
+                return getObjects(fields, filters, apiName, additionnalQueryFields)
+                    .error(function () {
+                        throw new Error('getHostProblems : GET Request failed');
+                    });
+            };
         }])
 
     // This service is used to count the number of service problems
     .service('getServiceProblems', ['$http', 'getObjects',
         function ($http, getObjects) {
-            var fields = ['state'],
-                filters = { 'isnot': {'state': [0]} },
-                apiName = 'services',
-                additionnalQueryFields = {};
+            return function () {
+                var fields = ['state'],
+                    filters = { 'isnot': {'state': [0]} },
+                    apiName = 'services',
+                    additionnalQueryFields = {};
 
-            return getObjects(fields, filters, apiName, additionnalQueryFields)
-                .error(function () {
-                    throw new Error('getServiceOpenProblems : GET Request failed');
-                });
+                return getObjects(fields, filters, apiName, additionnalQueryFields)
+                    .error(function () {
+                        throw new Error('getServiceOpenProblems : GET Request failed');
+                    });
+            };
         }])
 
     // This service is used to count the number of hosts
     .service('getTotalHosts', ['$http', 'getObjects',
         function ($http, getObjects) {
-            var fields = ['name'],
-                filters = {},
-                apiName = 'hosts',
-                additionnalQueryFields = {};
+            return function () {
+                var fields = ['name'],
+                    filters = {},
+                    apiName = 'hosts',
+                    additionnalQueryFields = {};
 
-            return getObjects(fields, filters, apiName, additionnalQueryFields)
-                .error(function () {
-                    throw new Error('getTotalHosts : GET Request failed');
-                });
+                return getObjects(fields, filters, apiName, additionnalQueryFields)
+                    .error(function () {
+                        throw new Error('getTotalHosts : GET Request failed');
+                    });
+            };
         }])
 
     // This service is used to count the number of services
     .service('getTotalServices', ['$http', 'getObjects',
         function ($http, getObjects) {
-            var fields = ['name'],
-                filters = {},
-                apiName = 'services',
-                additionnalQueryFields = {};
+            return function () {
+                var fields = ['name'],
+                    filters = {},
+                    apiName = 'services',
+                    additionnalQueryFields = {};
 
-            return getObjects(fields, filters, apiName, additionnalQueryFields)
-                .error(function () {
-                    throw new Error('getTotalServices : GET Request failed');
-                });
+                return getObjects(fields, filters, apiName, additionnalQueryFields)
+                    .error(function () {
+                        throw new Error('getTotalServices : GET Request failed');
+                    });
+            };
         }])
 
     .service('getObjectId', ['$http', function ($http) {

--- a/app/components/live/notifications.js
+++ b/app/components/live/notifications.js
@@ -1,9 +1,0 @@
-'use strict';
-
-angular.module('adagios.live')
-
-    .factory('getProblems', [function () {
-        var problem_number = 44;
-
-        return problem_number;
-    }]);

--- a/app/components/service/service.js
+++ b/app/components/service/service.js
@@ -9,8 +9,7 @@ angular.module('adagios.service', ['adagios.live',
 
     .controller('ServiceCtrl', ['$scope', 'serviceConfig', 'getService',
         function ($scope, serviceConfig, getService) {
-            var objectType = 'service',
-                hostName = serviceConfig.hostName,
+            var hostName = serviceConfig.hostName,
                 description = serviceConfig.description;
 
             getService(hostName, description).success(function (data) {

--- a/app/components/service/service_info/service_info.js
+++ b/app/components/service/service_info/service_info.js
@@ -3,7 +3,7 @@
 angular.module('adagios.service.info', [])
 
     .controller('ServiceInfoCtrl', ['$scope', function ($scope) {
-        $scope.acknowledged = $scope.data[0].acknowledged === "1" ? "Yes": "No";
+        $scope.acknowledged = $scope.data[0].acknowledged === "1" ? "Yes" : "No";
     }])
 
     .directive('adgServiceInfo', function () {

--- a/app/components/service/service_metrics/service_metrics.js
+++ b/app/components/service/service_metrics/service_metrics.js
@@ -3,6 +3,7 @@
 angular.module('adagios.service.metrics', [])
 
     .controller('ServiceMetricsCtrl', ['$scope', function ($scope) {
+        angular.noop();
     }])
 
     .directive('adgServiceMetrics', function () {

--- a/app/components/table/cell_last_check/cell_last_check.html
+++ b/app/components/table/cell_last_check/cell_last_check.html
@@ -1,3 +1,3 @@
 <td class="data-table__lastcheck">
-  <time class="data-table__data">{{entry.last_check * 1000 | date: medium}}</time>
+  <time class="data-table__data">{{entry.last_check * 1000 | date: "medium"}}</time>
 </td>

--- a/app/components/table/table.js
+++ b/app/components/table/table.js
@@ -1,6 +1,7 @@
 'use strict';
 
 angular.module('adagios.table', ['adagios.live',
+                                 'adagios.utils.promiseManager',
                                  'adagios.table.actionbar',
                                  'adagios.filters',
                                  'adagios.table.cell_host',
@@ -16,10 +17,9 @@ angular.module('adagios.table', ['adagios.live',
 
     .value('tablesConfig', [])
 
-    .value('ajaxQueries', [])
-
-    .controller('TableCtrl', ['$scope', '$interval', 'getObjects', 'tablesConfig', 'actionbarFilters', 'ajaxQueries', 'tableGlobalConfig',
-        function ($scope, $interval, getObjects, tablesConfig, actionbarFilters, ajaxQueries, tableGlobalConfig) {
+    .controller('TableCtrl', ['$scope', '$interval', 'getObjects', 'tablesConfig',
+        'actionbarFilters', 'addAjaxPromise', 'tableGlobalConfig',
+        function ($scope, $interval, getObjects, tablesConfig, actionbarFilters, addAjaxPromise, tableGlobalConfig) {
             var requestFields = [],
                 conf = tablesConfig[tableGlobalConfig.nextTableIndex],
                 getData,
@@ -49,7 +49,7 @@ angular.module('adagios.table', ['adagios.live',
             getData(requestFields, conf.filters, conf.apiName, conf.additionnalQueryFields);
 
             if (tableGlobalConfig.refreshInterval !== 0) {
-                ajaxQueries.push(
+                addAjaxPromise(
                     $interval(function () {
                         getData(requestFields, conf.filters, conf.apiName, conf.additionnalQueryFields);
                     }, tableGlobalConfig.refreshInterval)
@@ -138,14 +138,9 @@ angular.module('adagios.table', ['adagios.live',
         };
     }])
 
-    .service('reinitTables', ['$interval', 'ajaxQueries', 'tablesConfig', 'tableGlobalConfig',
-        function ($interval, ajaxQueries, tablesConfig, tableGlobalConfig) {
+    .service('reinitTables', ['$interval', 'tablesConfig', 'tableGlobalConfig',
+        function ($interval, tablesConfig, tableGlobalConfig) {
             return function () {
-                // Stop AJAX queries
-                angular.forEach(ajaxQueries, function (promise) {
-                    $interval.cancel(promise);
-                });
-
                 // Reinitialise table index
                 tableGlobalConfig.nextTableIndex = 0;
             };

--- a/app/components/tactical/current_health/current_health.html
+++ b/app/components/tactical/current_health/current_health.html
@@ -1,4 +1,4 @@
-<table class="current-health" ng-app="adagios.tactical.current_health" ng-controller="TacticalCurrentHealth">
+<table ng-controller="TacticalCurrentHealth" class="current-health" ng-if="hostsRatio != 0 && servicesRatio != 0">
   <thead>
     <tr>
       <th>Current health</th>
@@ -8,10 +8,10 @@
   <tbody>
     <tr>
       <td class="layout__half">
-        <just-gage id="allservices" class="someClass" min=0 max=100 value=services title="ALL SERVICES"></just-gage>
+        <just-gage id="allservices" class="someClass" min=0 max=100 value=servicesRatio title="ALL SERVICES"></just-gage>
       </td>
       <td class="layout__half">
-        <just-gage id="allhosts" class="someClass" min=0 max=100 value=hosts title="ALL HOSTS"></just-gage>
+        <just-gage id="allhosts" class="someClass" min=0 max=100 value=hostsRatio title="ALL HOSTS"></just-gage>
       </td>
     </tr>
   </tbody>

--- a/app/components/tactical/current_health/current_health.html
+++ b/app/components/tactical/current_health/current_health.html
@@ -1,4 +1,6 @@
-<table ng-controller="TacticalCurrentHealth" class="current-health" ng-if="hostsRatio != 0 && servicesRatio != 0">
+<table ng-controller="TacticalCurrentHealth"
+       class="current-health"
+       ng-if="hostsRatio != 0 && servicesRatio != 0">
   <thead>
     <tr>
       <th>Current health</th>

--- a/app/components/tactical/current_health/current_health.js
+++ b/app/components/tactical/current_health/current_health.js
@@ -5,11 +5,14 @@ angular.module('adagios.tactical.current_health', ['adagios.live',
 
     .controller('TacticalCurrentHealth', ['$scope', 'getHostProblems', 'getServiceProblems', 'getTotalHosts', 'getTotalServices',
         function ($scope, getHostProblems, getServiceProblems, getTotalHosts, getTotalServices) {
+            $scope.hostsRatio = 0;
+            $scope.servicesRatio = 0;
+
             getHostProblems.success(function (data) {
                 $scope.hostProblems = data.length;
                 getTotalHosts.success(function (data) {
                     $scope.totalHosts = data.length;
-                    $scope.hosts = ($scope.totalHosts - $scope.hostProblems) / $scope.totalHosts * 100;
+                    $scope.hostsRatio = ($scope.totalHosts - $scope.hostProblems) / $scope.totalHosts * 100;
                 });
             });
 
@@ -17,7 +20,7 @@ angular.module('adagios.tactical.current_health', ['adagios.live',
                 $scope.serviceProblems = data.length;
                 getTotalServices.success(function (data) {
                     $scope.totalServices = data.length;
-                    $scope.services = ($scope.totalServices - $scope.serviceProblems) / $scope.totalServices * 100;
+                    $scope.servicesRatio = ($scope.totalServices - $scope.serviceProblems) / $scope.totalServices * 100;
                 });
             });
         }])

--- a/app/components/tactical/current_health/current_health.js
+++ b/app/components/tactical/current_health/current_health.js
@@ -3,27 +3,9 @@
 angular.module('adagios.tactical.current_health', ['adagios.live',
                                                    'ngJustGage'])
 
-    .controller('TacticalCurrentHealth', ['$scope', 'getHostProblems', 'getServiceProblems', 'getTotalHosts', 'getTotalServices',
-        function ($scope, getHostProblems, getServiceProblems, getTotalHosts, getTotalServices) {
-            $scope.hostsRatio = 0;
-            $scope.servicesRatio = 0;
-
-            getHostProblems.success(function (data) {
-                $scope.hostProblems = data.length;
-                getTotalHosts.success(function (data) {
-                    $scope.totalHosts = data.length;
-                    $scope.hostsRatio = ($scope.totalHosts - $scope.hostProblems) / $scope.totalHosts * 100;
-                });
-            });
-
-            getServiceProblems.success(function (data) {
-                $scope.serviceProblems = data.length;
-                getTotalServices.success(function (data) {
-                    $scope.totalServices = data.length;
-                    $scope.servicesRatio = ($scope.totalServices - $scope.serviceProblems) / $scope.totalServices * 100;
-                });
-            });
-        }])
+    .controller('TacticalCurrentHealth', ['$scope', function ($scope) {
+        angular.noop();
+    }])
 
     .directive('adgCurrentHealth', function () {
         return {

--- a/app/components/tactical/current_health/current_health.js
+++ b/app/components/tactical/current_health/current_health.js
@@ -1,11 +1,26 @@
 'use strict';
 
-angular.module('adagios.tactical.current_health', ['ngRoute', 'ngJustGage' ])
+angular.module('adagios.tactical.current_health', ['adagios.live',
+                                                   'ngJustGage'])
 
-    .controller('TacticalCurrentHealth', ['$scope', function ($scope) {
-        $scope.hosts =  75.2;
-        $scope.services = 94.4;
-    }])
+    .controller('TacticalCurrentHealth', ['$scope', 'getHostProblems', 'getServiceProblems', 'getTotalHosts', 'getTotalServices',
+        function ($scope, getHostProblems, getServiceProblems, getTotalHosts, getTotalServices) {
+            getHostProblems.success(function (data) {
+                $scope.hostProblems = data.length;
+                getTotalHosts.success(function (data) {
+                    $scope.totalHosts = data.length;
+                    $scope.hosts = ($scope.totalHosts - $scope.hostProblems) / $scope.totalHosts * 100;
+                });
+            });
+
+            getServiceProblems.success(function (data) {
+                $scope.serviceProblems = data.length;
+                getTotalServices.success(function (data) {
+                    $scope.totalServices = data.length;
+                    $scope.services = ($scope.totalServices - $scope.serviceProblems) / $scope.totalServices * 100;
+                });
+            });
+        }])
 
     .directive('adgCurrentHealth', function () {
         return {

--- a/app/components/tactical/status_overview/status_overview.html
+++ b/app/components/tactical/status_overview/status_overview.html
@@ -1,4 +1,6 @@
-<table ng-app="adagios.tactical.status_overview" ng-controller="TacticalStatusOverViewCtrl" class="table">
+<table ng-controller="TacticalStatusOverViewCtrl"
+       class="table"
+       ng-if="hostProblems != 0 && totalHosts != 0 && serviceProblems != 0 && totalServices != 0">
   <thead>
     <tr>
       <th>Status overview</th>
@@ -12,13 +14,13 @@
   <tbody>
     <tr>
       <th>Hosts</th>
-      <td>{{ hosts.count }}</td>
-      <td class="state--error alerts">{{ hosts.problems }}</td>
+      <td>{{totalHosts}}</td>
+      <td class="state--error alerts">{{hostProblems}}</td>
     </tr>  
     <tr>
       <th>Services</th>
-      <td>{{ services.count }}</td>
-      <td class="state--error alerts">{{ services.problems }}</td>
+      <td>{{totalServices}}</td>
+      <td class="state--error alerts">{{serviceProblems}}</td>
     </tr>
   </tbody>
 </table>

--- a/app/components/tactical/status_overview/status_overview.js
+++ b/app/components/tactical/status_overview/status_overview.js
@@ -3,15 +3,7 @@
 angular.module('adagios.tactical.status_overview', ['ngRoute' ])
 
     .controller('TacticalStatusOverViewCtrl', ['$scope', function ($scope) {
-        $scope.hosts = {
-            "count": 104,
-            "problems": 14
-        };
-
-        $scope.services = {
-            "count": 1126,
-            "problems": 42
-        };
+        angular.noop();
     }])
 
     .directive('adgStatusOverview', function () {

--- a/app/components/tactical/tactical.js
+++ b/app/components/tactical/tactical.js
@@ -28,17 +28,17 @@ angular.module('adagios.tactical', ['adagios.tactical.status_overview',
             $scope.serviceProblems = 0;
             $scope.totalServices = 0;
 
-            getHostProblems.success(function (data) {
+            getHostProblems().success(function (data) {
                 $scope.hostProblems = data.length;
-                getTotalHosts.success(function (data) {
+                getTotalHosts().success(function (data) {
                     $scope.totalHosts = data.length;
                     $scope.hostsRatio = ($scope.totalHosts - $scope.hostProblems) / $scope.totalHosts * 100;
                 });
             });
 
-            getServiceProblems.success(function (data) {
+            getServiceProblems().success(function (data) {
                 $scope.serviceProblems = data.length;
-                getTotalServices.success(function (data) {
+                getTotalServices().success(function (data) {
                     $scope.totalServices = data.length;
                     $scope.servicesRatio = ($scope.totalServices - $scope.serviceProblems) / $scope.totalServices * 100;
                 });
@@ -49,7 +49,7 @@ angular.module('adagios.tactical', ['adagios.tactical.status_overview',
             $('a[data-toggle="tab"]').on('click', function (evt) {
                 evt.preventDefault();
             });
-    }])
+        }])
 
     .directive('adgTactical', ['tacticalConfig', function (tacticalConfig) {
         return {

--- a/app/components/tactical/tactical.js
+++ b/app/components/tactical/tactical.js
@@ -14,17 +14,41 @@ angular.module('adagios.tactical', ['adagios.tactical.status_overview',
         this.topAlertProducers = config.components.topAlertProducers;
     })
 
-    .controller('TacticalCtrl', ['$scope', 'tacticalConfig', function ($scope, tacticalConfig) {
+    .controller('TacticalCtrl', ['$scope', 'tacticalConfig', 'getHostProblems', 'getServiceProblems',
+        'getTotalHosts', 'getTotalServices',
+        function ($scope, tacticalConfig, getHostProblems, getServiceProblems, getTotalHosts, getTotalServices) {
+            $scope.statusOverview = tacticalConfig.statusOverview;
+            $scope.currentHealth = tacticalConfig.currentHealth;
+            $scope.topAlertProducers = tacticalConfig.topAlertProducers;
 
-        $scope.statusOverview = tacticalConfig.statusOverview;
-        $scope.currentHealth = tacticalConfig.currentHealth;
-        $scope.topAlertProducers = tacticalConfig.topAlertProducers;
+            $scope.hostsRatio = 0;
+            $scope.servicesRatio = 0;
+            $scope.hostProblems = 0;
+            $scope.totalHosts = 0;
+            $scope.serviceProblems = 0;
+            $scope.totalServices = 0;
 
-        // Togglable tabs
-        // Don't follow hyperlinks
-        $('a[data-toggle="tab"]').on('click', function (evt) {
-            evt.preventDefault();
-        });
+            getHostProblems.success(function (data) {
+                $scope.hostProblems = data.length;
+                getTotalHosts.success(function (data) {
+                    $scope.totalHosts = data.length;
+                    $scope.hostsRatio = ($scope.totalHosts - $scope.hostProblems) / $scope.totalHosts * 100;
+                });
+            });
+
+            getServiceProblems.success(function (data) {
+                $scope.serviceProblems = data.length;
+                getTotalServices.success(function (data) {
+                    $scope.totalServices = data.length;
+                    $scope.servicesRatio = ($scope.totalServices - $scope.serviceProblems) / $scope.totalServices * 100;
+                });
+            });
+
+            // Togglable tabs
+            // Don't follow hyperlinks
+            $('a[data-toggle="tab"]').on('click', function (evt) {
+                evt.preventDefault();
+            });
     }])
 
     .directive('adgTactical', ['tacticalConfig', function (tacticalConfig) {

--- a/app/components/tactical/tactical.js
+++ b/app/components/tactical/tactical.js
@@ -18,7 +18,9 @@ angular.module('adagios.tactical', ['adagios.live',
 
     .controller('TacticalCtrl', ['$scope', '$interval', 'tacticalConfig', 'getHostProblems', 'getServiceProblems',
         'getTotalHosts', 'getTotalServices', 'addAjaxPromise',
-        function ($scope, $interval, tacticalConfig, getHostProblems, getServiceProblems, getTotalHosts, getTotalServices, addAjaxPromise) {
+        function ($scope, $interval, tacticalConfig, getHostProblems, getServiceProblems, getTotalHosts,
+            getTotalServices, addAjaxPromise) {
+
             var getData;
 
             $scope.statusOverview = tacticalConfig.statusOverview;
@@ -32,7 +34,7 @@ angular.module('adagios.tactical', ['adagios.live',
             $scope.serviceProblems = 0;
             $scope.totalServices = 0;
 
-            getData= function () {
+            getData = function () {
                 getHostProblems().success(function (data) {
                     $scope.hostProblems = data.length;
                     getTotalHosts().success(function (data) {
@@ -48,7 +50,7 @@ angular.module('adagios.tactical', ['adagios.live',
                         $scope.servicesRatio = ($scope.totalServices - $scope.serviceProblems) / $scope.totalServices * 100;
                     });
                 });
-            }
+            };
 
             if (tacticalConfig.refreshInterval !== 0) {
                 addAjaxPromise(

--- a/app/components/tactical/tactical.js
+++ b/app/components/tactical/tactical.js
@@ -59,9 +59,9 @@ angular.module('adagios.tactical', ['adagios.tactical.status_overview',
                 return {
                     pre: function preLink(scope, iElement, iAttrs, controller) {
                         // This is the earliest phase during which attributes are evaluated
-                        tacticalConfig.statusOverview = JSON.parse(iAttrs.statusOverview.toLowerCase());
-                        tacticalConfig.currentHealth = JSON.parse(iAttrs.currentHealth.toLowerCase());
-                        tacticalConfig.topAlertProducers = JSON.parse(iAttrs.topAlertProducers.toLowerCase());
+                        tacticalConfig.statusOverview = JSON.parse(iAttrs.statusOverview);
+                        tacticalConfig.currentHealth = JSON.parse(iAttrs.currentHealth);
+                        tacticalConfig.topAlertProducers = JSON.parse(iAttrs.topAlertProducers);
                     }
                 };
             }

--- a/app/components/topbar/topbar.html
+++ b/app/components/topbar/topbar.html
@@ -20,7 +20,7 @@
               aria-expanded="false"
               aria-controls="notificationsPanel">
         <span class="visuallyhidden">Voir les notifications</span>
-        <i class="ico-bell-alt" data-notifications="{{ notifications }}"></i>
+        <i class="ico-bell-alt" data-notifications="{{serviceProblems}}"></i>
       </button>
       
       <div class="topbar__panel--fromleft collapse" id="notificationsPanel">

--- a/app/components/topbar/topbar.html
+++ b/app/components/topbar/topbar.html
@@ -20,7 +20,7 @@
               aria-expanded="false"
               aria-controls="notificationsPanel">
         <span class="visuallyhidden">Voir les notifications</span>
-        <i class="ico-bell-alt" data-notifications="{{serviceProblems}}"></i>
+        <i class="ico-bell-alt" data-notifications="{{allProblems}}"></i>
       </button>
       
       <div class="topbar__panel--fromleft collapse" id="notificationsPanel">

--- a/app/components/topbar/topbar.js
+++ b/app/components/topbar/topbar.js
@@ -3,7 +3,7 @@
 angular.module('adagios.topbar', ['adagios.live'])
 
     .controller('TopBarCtrl', ['$scope', 'getServiceProblems', function ($scope, getServiceProblems) {
-        getServiceProblems.success(function (data) {
+        getServiceProblems().success(function (data) {
             $scope.serviceProblems = data.length;
         });
     }])

--- a/app/components/topbar/topbar.js
+++ b/app/components/topbar/topbar.js
@@ -2,8 +2,10 @@
 
 angular.module('adagios.topbar', ['adagios.live'])
 
-    .controller('TopBarCtrl', ['$scope', 'getProblems', function ($scope, getProblems) {
-        $scope.notifications = getProblems;
+    .controller('TopBarCtrl', ['$scope', 'getServiceProblems', function ($scope, getServiceProblems) {
+        getServiceProblems.success(function (data) {
+            $scope.serviceProblems = data.length;
+        });
     }])
 
     .directive('adgTopbar', function () {

--- a/app/components/topbar/topbar.js
+++ b/app/components/topbar/topbar.js
@@ -2,11 +2,26 @@
 
 angular.module('adagios.topbar', ['adagios.live'])
 
-    .controller('TopBarCtrl', ['$scope', 'getServiceProblems', function ($scope, getServiceProblems) {
-        getServiceProblems().success(function (data) {
-            $scope.serviceProblems = data.length;
-        });
-    }])
+    .controller('TopBarCtrl', ['$scope', '$interval', 'getServiceProblems', 'getHostProblems', 'addAjaxPromise',
+        function ($scope, $interval, getServiceProblems, getHostProblems, addAjaxPromise) {
+            var getData,
+                hostProblems,
+                serviceProblems;
+
+            getData = function () {
+                getServiceProblems().success(function (data) {
+                    serviceProblems = data.length;
+                    getHostProblems().success(function (data) {
+                        hostProblems = data.length;
+                        $scope.allProblems = serviceProblems + hostProblems;
+                    });
+                });
+            };
+
+            // TODO: Change hardcoded interval when the topbar dashboard will be implemented
+            addAjaxPromise($interval(getData, 10000));
+            getData();
+        }])
 
     .directive('adgTopbar', function () {
         return {

--- a/app/components/utils/promise_manager.js
+++ b/app/components/utils/promise_manager.js
@@ -1,0 +1,26 @@
+'use strict';
+
+angular.module('adagios.utils.promiseManager', [])
+
+    .value('ajaxPromises', [])
+
+    .service('addAjaxPromise', ['ajaxPromises', function (ajaxPromises) {
+        return function (promise) {
+            ajaxPromises.push(promise);
+        };
+    }])
+
+    .service('clearAjaxPromises', ['$interval', 'ajaxPromises', function (ajaxPromises) {
+        return function ($interval) {
+            angular.forEach(ajaxPromises, function (promise) {
+                $interval.cancel(promise);
+            });
+        };
+    }])
+
+    .service('clearAllPromises', ['ajaxPromises', 'clearAjaxPromises',
+        function (ajaxPromises, clearAjaxPromises) {
+            return function () {
+                clearAjaxPromises();
+            };
+        }]);

--- a/app/components/utils/promise_manager.js
+++ b/app/components/utils/promise_manager.js
@@ -10,8 +10,8 @@ angular.module('adagios.utils.promiseManager', [])
         };
     }])
 
-    .service('clearAjaxPromises', ['$interval', 'ajaxPromises', function (ajaxPromises) {
-        return function ($interval) {
+    .service('clearAjaxPromises', ['$interval', 'ajaxPromises', function ($interval, ajaxPromises) {
+        return function () {
             angular.forEach(ajaxPromises, function (promise) {
                 $interval.cancel(promise);
             });

--- a/app/templates/dashboard/dashboard.html
+++ b/app/templates/dashboard/dashboard.html
@@ -19,7 +19,7 @@
              aria-expanded="true"
              role="tab"
              data-toggle="tab"
-             data-problems="{{nbServiceOpenProblems}}">Open problems
+             data-problems="{{totalOpenProblems}}">Open problems
           </a>
         </li>
         <li role="presentation" class="tablist__item">
@@ -29,7 +29,7 @@
              aria-expanded="false"
              role="tab"
              data-toggle="tab"
-             data-problems="{{nbServiceProblems}}">All problems
+             data-problems="{{totalProblems}}">All problems
           </a>
         </li>
       </ul>

--- a/app/templates/dashboard/dashboard.html
+++ b/app/templates/dashboard/dashboard.html
@@ -4,7 +4,8 @@
     
     <adg-tactical status-overview="{{dashboardTactical[0].statusOverview}}"
                   current-health="{{dashboardTactical[0].currentHealth}}"
-                  top-alert-producers="{{dashboardTactical[0].topAlertProducers}}"></adg-tactical>
+                  top-alert-producers="{{dashboardTactical[0].topAlertProducers}}"
+                  refresh-interval="{{dashboardRefreshInterval}}"></adg-tactical>
     
   </header>
   

--- a/app/templates/dashboard/dashboard.html
+++ b/app/templates/dashboard/dashboard.html
@@ -38,78 +38,87 @@
     
     <div class="tab-content">
       <div role="tabpanel" class="problems tab-pane active" id="openProblems">
-        <header class="main__content__header clearfix">
-          <h2 class="main__content__title">{{dashboardTables[0].title}}</h2>
-          <p class="main__content__alert state--error">
-            There are {{nbHostOpenProblems}} host
-            <ng-pluralize count="nbHostOpenProblems" when="{'0':'problem', '1': 'problem', 'other': 'problems'}"/>
-          </p>
-        </header>
+        <span ng-hide="nbHostOpenProblems == 0">
+          <header class="main__content__header clearfix">
+            <h2 class="main__content__title">{{dashboardTables[0].title}}</h2>
+            <p class="main__content__alert state--error">
+              There are {{nbHostOpenProblems}} host
+              <ng-pluralize count="nbHostOpenProblems" when="{'0':'problem', '1': 'problem', 'other': 'problems'}"/>
+            </p>
+          </header>
 
-        <adg-table cells-text="{{dashboardTables[0].CellsText}}"
-                   cells-name="{{dashboardTables[0].CellsName}}"
-                   api-name="{{dashboardTables[0].ApiName}}"
-                   filters="{{dashboardTables[0].Filters}}"
-                   is-wrappable="{{dashboardTables[0].IsWrappable}}"
-                   no-repeat-cell="{{dashboardTables[0].NoRepeatCell}}"
-                   refresh-interval="{{dashboardRefreshInterval}}"
-                   additionnal-query-fields="{{dashboardTables[0].additionnalQueryFields}}"
-                   table-id="0"></adg-table>
+          <adg-table cells-text="{{dashboardTables[0].CellsText}}"
+                     cells-name="{{dashboardTables[0].CellsName}}"
+                     api-name="{{dashboardTables[0].ApiName}}"
+                     filters="{{dashboardTables[0].Filters}}"
+                     is-wrappable="{{dashboardTables[0].IsWrappable}}"
+                     no-repeat-cell="{{dashboardTables[0].NoRepeatCell}}"
+                     refresh-interval="{{dashboardRefreshInterval}}"
+                     additionnal-query-fields="{{dashboardTables[0].additionnalQueryFields}}"
+                     table-id="0"></adg-table>
 
-        <header class="main__content__header clearfix">
-          <h2 class="main__content__title">{{dashboardTables[1].title}}</h2>
-          <p class="main__content__alert state--error">
-            There are {{nbServiceOpenProblems}} host
-            <ng-pluralize count="nbServiceOpenProblems" when="{'0':'problem', '1': 'problem', 'other': 'problems'}"/>
-          </p>
-        </header>
+        </span>
 
-        <adg-table cells-text="{{dashboardTables[1].CellsText}}"
-                   cells-name="{{dashboardTables[1].CellsName}}"
-                   api-name="{{dashboardTables[1].ApiName}}"
-                   filters="{{dashboardTables[1].Filters}}"
-                   is-wrappable="{{dashboardTables[1].IsWrappable}}"
-                   no-repeat-cell="{{dashboardTables[1].NoRepeatCell}}"
-                   refresh-interval="{{dashboardRefreshInterval}}"
-                   additionnal-query-fields="{{dashboardTables[1].additionnalQueryFields}}"
-                   table-id="1"></adg-table>
-        
+        <span ng-hide="nbServiceOpenProblems == 0">
+          <header class="main__content__header clearfix">
+            <h2 class="main__content__title">{{dashboardTables[1].title}}</h2>
+            <p class="main__content__alert state--error">
+              There are {{nbServiceOpenProblems}} host
+              <ng-pluralize count="nbServiceOpenProblems" when="{'0':'problem', '1': 'problem', 'other': 'problems'}"/>
+            </p>
+          </header>
+
+          <adg-table cells-text="{{dashboardTables[1].CellsText}}"
+                     cells-name="{{dashboardTables[1].CellsName}}"
+                     api-name="{{dashboardTables[1].ApiName}}"
+                     filters="{{dashboardTables[1].Filters}}"
+                     is-wrappable="{{dashboardTables[1].IsWrappable}}"
+                     no-repeat-cell="{{dashboardTables[1].NoRepeatCell}}"
+                     refresh-interval="{{dashboardRefreshInterval}}"
+                     additionnal-query-fields="{{dashboardTables[1].additionnalQueryFields}}"
+                     table-id="1"></adg-table>
+          
+        </span>
       </div>
       
       <div role="tabpanel" class="problems tab-pane" id="allProblems">
-        <header class="main__content__header clearfix">
-          <h2 class="main__content__title">{{dashboardTables[2].title}}</h2>
-          <p class="main__content__alert state--error">
-            There are {{nbHostProblems}} host
-            <ng-pluralize count="nbHostProblems" when="{'0':'problem', '1': 'problem', 'other': 'problems'}"/>
-          </p>
-        </header>
+        <span ng-hide="nbHostProblems == 0">
+          <header class="main__content__header clearfix">
+            <h2 class="main__content__title">{{dashboardTables[2].title}}</h2>
+            <p class="main__content__alert state--error">
+              There are {{nbHostProblems}} host
+              <ng-pluralize count="nbHostProblems" when="{'0':'problem', '1': 'problem', 'other': 'problems'}"/>
+            </p>
+          </header>
 
-        <adg-table cells-text="{{dashboardTables[2].CellsText}}"
-                   cells-name="{{dashboardTables[2].CellsName}}"
-                   api-name="{{dashboardTables[2].ApiName}}"
-                   filters="{{dashboardTables[2].Filters}}"
-                   is-wrappable="{{dashboardTables[2].IsWrappable}}"
-                   no-repeat-cell="{{dashboardTables[2].NoRepeatCell}}"
-                   refresh-interval="{{dashboardRefreshInterval}}"
-                   table-id="2"></adg-table>
+          <adg-table cells-text="{{dashboardTables[2].CellsText}}"
+                     cells-name="{{dashboardTables[2].CellsName}}"
+                     api-name="{{dashboardTables[2].ApiName}}"
+                     filters="{{dashboardTables[2].Filters}}"
+                     is-wrappable="{{dashboardTables[2].IsWrappable}}"
+                     no-repeat-cell="{{dashboardTables[2].NoRepeatCell}}"
+                     refresh-interval="{{dashboardRefreshInterval}}"
+                     table-id="2"></adg-table>
+        </span>
 
-        <header class="main__content__header clearfix">
-          <h2 class="main__content__title">{{dashboardTables[3].title}}</h2>
-          <p class="main__content__alert state--error">
-            There are {{nbServiceProblems}} service
-            <ng-pluralize count="nbServiceProblems" when="{'0':'problem', '1': 'problem', 'other': 'problems'}"/>
-          </p>
-        </header>
+        <span ng-hide="nbServiceProblems == 0">
+          <header class="main__content__header clearfix">
+            <h2 class="main__content__title">{{dashboardTables[3].title}}</h2>
+            <p class="main__content__alert state--error">
+              There are {{nbServiceProblems}} service
+              <ng-pluralize count="nbServiceProblems" when="{'0':'problem', '1': 'problem', 'other': 'problems'}"/>
+            </p>
+          </header>
 
-        <adg-table cells-text="{{dashboardTables[3].CellsText}}"
-                   cells-name="{{dashboardTables[3].CellsName}}"
-                   api-name="{{dashboardTables[3].ApiName}}"
-                   filters="{{dashboardTables[3].Filters}}"
-                   is-wrappable="{{dashboardTables[3].IsWrappable}}"
-                   no-repeat-cell="{{dashboardTables[3].NoRepeatCell}}"
-                   refresh-interval="{{dashboardRefreshInterval}}"
-                   table-id="3"></adg-table>
+          <adg-table cells-text="{{dashboardTables[3].CellsText}}"
+                     cells-name="{{dashboardTables[3].CellsName}}"
+                     api-name="{{dashboardTables[3].ApiName}}"
+                     filters="{{dashboardTables[3].Filters}}"
+                     is-wrappable="{{dashboardTables[3].IsWrappable}}"
+                     no-repeat-cell="{{dashboardTables[3].NoRepeatCell}}"
+                     refresh-interval="{{dashboardRefreshInterval}}"
+                     table-id="3"></adg-table>
+       </span>
       </div>
     </div>
     

--- a/app/templates/dashboard/dashboard.html
+++ b/app/templates/dashboard/dashboard.html
@@ -63,7 +63,7 @@
           <header class="main__content__header clearfix">
             <h2 class="main__content__title">{{dashboardTables[1].title}}</h2>
             <p class="main__content__alert state--error">
-              There are {{nbServiceOpenProblems}} host
+              There are {{nbServiceOpenProblems}} service
               <ng-pluralize count="nbServiceOpenProblems" when="{'0':'problem', '1': 'problem', 'other': 'problems'}"/>
             </p>
           </header>

--- a/app/templates/dashboard/dashboard.html
+++ b/app/templates/dashboard/dashboard.html
@@ -18,7 +18,7 @@
              aria-expanded="true"
              role="tab"
              data-toggle="tab"
-             data-problems="27">Open problems
+             data-problems="{{nbServiceOpenProblems}}">Open problems
           </a>
         </li>
         <li role="presentation" class="tablist__item">
@@ -28,7 +28,7 @@
              aria-expanded="false"
              role="tab"
              data-toggle="tab"
-             data-problems="38">All problems
+             data-problems="{{nbServiceProblems}}">All problems
           </a>
         </li>
       </ul>

--- a/app/templates/dashboard/dashboard.html
+++ b/app/templates/dashboard/dashboard.html
@@ -43,8 +43,12 @@
           <header class="main__content__header clearfix">
             <h2 class="main__content__title">{{dashboardTables[0].title}}</h2>
             <p class="main__content__alert state--error">
-              There are {{nbHostOpenProblems}} host
-              <ng-pluralize count="nbHostOpenProblems" when="{'0':'problem', '1': 'problem', 'other': 'problems'}"/>
+              There 
+              <ng-pluralize count="nbHostOpenProblems" when="{'0':'is', '1': 'is', 'other': 'are'}">
+              </ng-pluralize>
+              are {{nbHostOpenProblems}} host
+              <ng-pluralize count="nbHostOpenProblems" when="{'0':'problem', '1': 'problem', 'other': 'problems'}">
+              </ng-pluralize>
             </p>
           </header>
 
@@ -64,8 +68,12 @@
           <header class="main__content__header clearfix">
             <h2 class="main__content__title">{{dashboardTables[1].title}}</h2>
             <p class="main__content__alert state--error">
-              There are {{nbServiceOpenProblems}} service
+              There 
+              <ng-pluralize count="nbServiceOpenProblems" when="{'0':'is', '1': 'is', 'other': 'are'}">
+              </ng-pluralize>
+              {{nbServiceOpenProblems}} service
               <ng-pluralize count="nbServiceOpenProblems" when="{'0':'problem', '1': 'problem', 'other': 'problems'}"/>
+              </ng-pluralize>
             </p>
           </header>
 
@@ -87,8 +95,12 @@
           <header class="main__content__header clearfix">
             <h2 class="main__content__title">{{dashboardTables[2].title}}</h2>
             <p class="main__content__alert state--error">
-              There are {{nbHostProblems}} host
+              There 
+              <ng-pluralize count="nbHostProblems" when="{'0':'is', '1': 'is', 'other': 'are'}"/>
+              </ng-pluralize>
+              {{nbHostProblems}} host
               <ng-pluralize count="nbHostProblems" when="{'0':'problem', '1': 'problem', 'other': 'problems'}"/>
+              </ng-pluralize>
             </p>
           </header>
 
@@ -106,8 +118,12 @@
           <header class="main__content__header clearfix">
             <h2 class="main__content__title">{{dashboardTables[3].title}}</h2>
             <p class="main__content__alert state--error">
-              There are {{nbServiceProblems}} service
+              There 
+              <ng-pluralize count="nbServiceProblems" when="{'0':'is', '1': 'is', 'other': 'are'}"/>
+              </ng-pluralize>
+              {{nbServiceProblems}} service
               <ng-pluralize count="nbServiceProblems" when="{'0':'problem', '1': 'problem', 'other': 'problems'}"/>
+              </ng-pluralize>
             </p>
           </header>
 

--- a/app/templates/dashboard/dashboard.js
+++ b/app/templates/dashboard/dashboard.js
@@ -44,18 +44,18 @@ angular.module('adagios.view.dashboard', ['ngRoute',
             getData = function () {
                 getHostOpenProblems().success(function (data) {
                     $scope.nbHostOpenProblems = data.length;
-                });
-
-                getServiceOpenProblems().success(function (data) {
-                    $scope.nbServiceOpenProblems = data.length;
+                    getServiceOpenProblems().success(function (data) {
+                        $scope.nbServiceOpenProblems = data.length;
+                        $scope.totalOpenProblems = $scope.nbServiceOpenProblems + $scope.nbHostOpenProblems;
+                    });
                 });
 
                 getHostProblems().success(function (data) {
                     $scope.nbHostProblems = data.length;
-                });
-
-                getServiceProblems().success(function (data) {
-                    $scope.nbServiceProblems = data.length;
+                    getServiceProblems().success(function (data) {
+                        $scope.nbServiceProblems = data.length;
+                        $scope.totalProblems = $scope.nbHostProblems + $scope.nbServiceProblems;
+                    });
                 });
             };
 

--- a/app/templates/service/service.js
+++ b/app/templates/service/service.js
@@ -3,7 +3,7 @@
 angular.module("adagios.view.service", [ "adagios.live" ])
 
     .controller("ServiceViewCtrl", [ "$scope", "$routeParams",
-        function($scope, $routeParams) {
+        function ($scope, $routeParams) {
 
             if (!$routeParams.host_name || !$routeParams.description) {
                 throw new Error("ERROR :'host_name' and 'description' GET parameters must be set");


### PR DESCRIPTION
- All dashboard's view components display real data
- Introducing a promise manager which is used to store redundant queries (or other redundant services triggered by $timeout). Everything that we feed it with will get cleared on url change.
- All AJAX queries are redundants based on config refreshInterval attribute.
